### PR TITLE
bug for non medical professionals not being displayed works

### DIFF
--- a/app/views/referrals/admin.html.erb
+++ b/app/views/referrals/admin.html.erb
@@ -27,7 +27,7 @@
     </thead>
 
     <tbody>
-        <% Referral.where(medical_prof: true).each do |referral|%>
+        <% Referral.all.each do |referral|%>
             <tr>
               <% that_user=User.find_by(id: referral.old_member)%>
               <%if that_user.present?%>


### PR DESCRIPTION
ignore branch name. I fixed the bug where admins were unable to view referrals for non medical professionals.